### PR TITLE
Add who's next functionality: get the name of the person who will get to go for a rsvp cancellation comment.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,13 +1,30 @@
 meetup-whereami
 ===============
 
-Bookmarklet that finds your position on the waitlist.
+Two Bookmarklets for use with Meetup.com to get information on oversubscribed events. Go to the event page of interest and run the desired bookmarklet script. Warning: Both of these are hacky ways to get the info so they might break when meetup.com decides to change things. 
 
+1.To find your numerical position on the waitlist, run whereami.js :
 Add this bookmark:
 ```javascript
 javascript:(function(a){var b=a.createElement("script");b.src="https://raw.github.com/larsericsson/meetup-whereami/master/whereami.js";a.getElementsByTagName("head")[0].appendChild(b)})(document);
 ```
 
-Go to the specific meetup page and hit the bookmark.
+This gives you a rough estimate on where you are on the waitlist. It doesn't account for +1's right now.
 
-This gives you a rough estimate on where you are on the waitlist. It doesn't account for +1's right now and since it's quite a hacky way to get the info it might break when meetup.com decides to change things.
+1a.Known bug: If your name appears on the page in a comment but on neither the going or waitlist people, the script says "you're going."
+1b.To permanently install a bookmarklet on Firefox, merely drag the below code to the bookmarklet menu.
+
+2.If you cancel on the same day, thus offering up your position, it is courteous to leave a comment advising next person in line. To copy that person's name, run whonext.js : 
+```javascript
+javascript:(function(a){var b=a.createElement("script");b.src="https://raw.github.com/AnneTheAgile/meetup-whereami/master/whonext.js";a.getElementsByTagName("head")[0].appendChild(b)})(document);
+```
+
+2a.NB: The URL's differ for [2] vs [1] because AnneTheAgile's pull request is pending.
+
+3.For your testing pleasure, three NYC groups whose events are often oversubscribed are:
+http://www.meetup.com/nycpython/
+http://www.meetup.com/NYC-Machine-Learning/
+http://www.meetup.com/nychtml5/
+
+
+

--- a/README.md
+++ b/README.md
@@ -14,12 +14,15 @@ This gives you a rough estimate on where you are on the waitlist. It doesn't acc
 1a.Known bug: If your name appears on the page in a comment but on neither the going or waitlist people, the script says "you're going."
 1b.To permanently install a bookmarklet on Firefox, merely drag the below code to the bookmarklet menu.
 
-2.If you cancel on the same day, thus offering up your position, it is courteous to leave a comment advising next person in line. To copy that person's name, run whonext.js : 
+
+2.If you cancel on the same day, thus offering up your position, it is courteous to leave a comment advising next person in line. 
+BEFORE clicking cancel, run this script to copy a message for that person: whonext.js : 
 ```javascript
 javascript:(function(a){var b=a.createElement("script");b.src="https://raw.github.com/AnneTheAgile/meetup-whereami/master/whonext.js";a.getElementsByTagName("head")[0].appendChild(b)})(document);
 ```
 
 2a.NB: The URL's differ for [2] vs [1] because AnneTheAgile's pull request is pending.
+
 
 3.For your testing pleasure, three NYC groups whose events are often oversubscribed are:
 http://www.meetup.com/nycpython/

--- a/whonext.js
+++ b/whonext.js
@@ -9,9 +9,8 @@
 
   if (subItem.text != "") {
     var x = "I am cancelling, so now "+ subItem.text +" gets to go."; 
-    // does nil on Firefox when from github? Worked in test mode; window.prompt
-    alert(subItem.text + " is the next person who will get to go from the waitlist\n"+"Copy and paste this as a comment\n", x);
     //Example; I am cancelling, so now Anne gets to go.
+    alert(subItem.text + " is the next person who will get to go from the waitlist\n" + "Copy and paste this as a comment\n" + x);
     }
   else 
     alert("Error? Nothing in ; "+subItem.text)

--- a/whonext.js
+++ b/whonext.js
@@ -1,0 +1,14 @@
+(function(window) {
+  // was var $waitlistEl = $('#rsvp-list-waitlist');
+  var doc = document, obj = { meta: [], taxonomy: [] };
+  var item = document.querySelector('#rsvp-list-waitlist li:first-child'),
+    subItem = item.querySelector('.figureset-description h5 a');
+ 
+  console.log(subItem.text); // "Sub-menu Item"
+
+  if (subItem.text != "")
+    alert(subItem.text + " is the next person who will get to go from the waitlist");
+  else 
+    alert("Error? Nothing in ; "+subItem.text)
+
+})(window);

--- a/whonext.js
+++ b/whonext.js
@@ -6,10 +6,13 @@
  
   console.log(subItem.text); // "Sub-menu Item"
 
-  if (subItem.text != "")
+
+  if (subItem.text != "") {
     var x = "I am cancelling, so now "+ subItem.text +" gets to go."; 
     // does nil on Firefox when from github? Worked in test mode; window.prompt
     alert(subItem.text + " is the next person who will get to go from the waitlist\n"+"Copy and paste this as a comment\n", x);
+    //Example; I am cancelling, so now Anne gets to go.
+    }
   else 
     alert("Error? Nothing in ; "+subItem.text)
 

--- a/whonext.js
+++ b/whonext.js
@@ -7,10 +7,9 @@
   console.log(subItem.text); // "Sub-menu Item"
 
   if (subItem.text != "")
-    alert(subItem.text + " is the next person who will get to go from the waitlist");
+    var x = "I am cancelling, so now "+ subItem.text +" gets to go."; 
+    window.prompt(subItem.text + " is the next person who will get to go from the waitlist\n"+"Copy and paste this as a comment\n", x);
   else 
     alert("Error? Nothing in ; "+subItem.text)
-    
-  window.prompt("Copy to clipboard: Ctrl+C, Enter", subItem.text);
 
 })(window);

--- a/whonext.js
+++ b/whonext.js
@@ -8,7 +8,8 @@
 
   if (subItem.text != "")
     var x = "I am cancelling, so now "+ subItem.text +" gets to go."; 
-    window.prompt(subItem.text + " is the next person who will get to go from the waitlist\n"+"Copy and paste this as a comment\n", x);
+    // does nil on Firefox when from github? Worked in test mode; window.prompt
+    alert(subItem.text + " is the next person who will get to go from the waitlist\n"+"Copy and paste this as a comment\n", x);
   else 
     alert("Error? Nothing in ; "+subItem.text)
 

--- a/whonext.js
+++ b/whonext.js
@@ -10,5 +10,7 @@
     alert(subItem.text + " is the next person who will get to go from the waitlist");
   else 
     alert("Error? Nothing in ; "+subItem.text)
+    
+  window.prompt("Copy to clipboard: Ctrl+C, Enter", subItem.text);
 
 })(window);


### PR DESCRIPTION
Added a new js and updated the docs readme. Running whonext will enable copy pasting a string:  "I am cancelling, so now USERNAME gets to go." Given that, one can paste it into a meetup comment prior to clicking cancel - thus advising the person who gets to go in the email that they will receive. They won't need to checkin to the website to find out if they were the one who got in.

My Git commits are a bit messy, will it squash them if you accept ? Or do I need to clean them to make just one?

Thank you Lars for inspiring me!
